### PR TITLE
Support React Native headers for RN version 0.40+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.2
+-----
+
+Support React Native headers both in the React namespace, where they are in RN version 0.40+,
+and no namespace, for older versions of React Native
+
 1.0.1
 -----
 

--- a/DeviceUtil.h
+++ b/DeviceUtil.h
@@ -1,4 +1,10 @@
+// Support React Native headers both in the React namespace, where they are in RN version 0.40+,
+// and no namespace, for older versions of React Native
+#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
+#else
+#import "RCTBridge.h"
+#endif
 
 @interface DeviceUtil : NSObject <RCTBridgeModule>
 

--- a/DeviceUtil.m
+++ b/DeviceUtil.m
@@ -1,6 +1,16 @@
 #import "DeviceUtil.h"
+// Support React Native headers both in the React namespace, where they are in RN version 0.40+,
+// and no namespace, for older versions of React Native
+#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
+#else
+#import "RCTBridge.h"
+#endif
+#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
+#else
+#import "RCTUtils.h"
+#endif
 #import <sys/utsname.h>
 
 @implementation DeviceUtil

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "UIDevice wrapper for React Native",
   "main": "Device.js",
   "scripts": {


### PR DESCRIPTION
Support React Native headers for RN version 0.40+
also provide backwards compatibility with no namespace, for older versions of React Native